### PR TITLE
scrape: move to shared postgres db

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ weaviate-client==3.10.0
 SQLAlchemy==1.4.46
 SQLAlchemy_Utils==0.39.0
 psycopg2-binary==2.9.5
+qcore==1.8.0

--- a/scrape/models.py
+++ b/scrape/models.py
@@ -12,11 +12,14 @@ from sqlalchemy import (  # type: ignore
 from sqlalchemy.orm import (  # type: ignore
     scoped_session, sessionmaker, relationship,
     backref)
+from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.ext.declarative import declarative_base  # type: ignore
 from sqlalchemy_utils import ChoiceType, Timestamp  # type: ignore
 
+import utils
 
-engine = create_engine('sqlite:///scrape.db')  # type: ignore
+
+engine = create_engine(utils.SCRAPEDB_URL)  # type: ignore
 db_session = scoped_session(sessionmaker(autocommit=False,
                                          autoflush=False,
                                          bind=engine))
@@ -29,6 +32,6 @@ class ScrapedUrl(Base, Timestamp):  # type: ignore
     __tablename__ = 'scraped_url'
     id = Column(Integer, primary_key=True)
     url = Column(String, nullable=False)
-    data = Column(JSON, nullable=False)
+    data = Column(JSONB, nullable=False)
 
     Index('scraped_url_lookup', url, unique=True)

--- a/utils.py
+++ b/utils.py
@@ -7,6 +7,7 @@ from langchain.llms import OpenAI
 OPENAI_API_KEY = "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"
 WEAVIATE_URL = "https://chatweb3:q0jficzXOA69T5FWgAeT@chatweb3.func.ai:5050"
 CHATDB_URL = "postgresql://chatdb:lVIu2U0lBctiYBScboAJ@chatweb3.func.ai:5433/chatdb"
+SCRAPEDB_URL = "postgresql://chatdb:lVIu2U0lBctiYBScboAJ@chatweb3.func.ai:5433/scrapedb"
 
 
 def set_api_key():


### PR DESCRIPTION
Used the following script for migration:
```
from typing import Any, Generator

import psycopg2.errors
import sqlalchemy

from scrape.models import (
    db_session, ScrapedUrl as ScrapedUrlModel,
)

def iter_scraped_urls() -> Generator[Any, None, None]:
    from index.sites import _yield_limit
    from scrape_old.models import ScrapedUrl as ScrapedUrlModelOld
    for scraped_url in _yield_limit(ScrapedUrlModelOld.query, ScrapedUrlModelOld.id):
        yield scraped_url


def run():
    for i, scraped_url in enumerate(iter_scraped_urls()):
        s = ScrapedUrlModel(
            url=scraped_url.url,
            data=scraped_url.data,
        )
        print(i, scraped_url.id, s.url)
        try:
            db_session.add(s)
            db_session.commit()
        except (sqlalchemy.exc.DataError, psycopg2.errors.UntranslatableCharacter):
            # some scraped data has \u0000 char which breaks when inserting into postgres
           db_session.rollback()


if __name__ == "__main__":
    run()
```