### PR TITLE
server: close db sessions after processing each message

### DIFF
--- a/server.py
+++ b/server.py
@@ -40,6 +40,11 @@ def client_left(client, server):
 
 
 def message_received(client, server, message):
+    _message_received(client, server, message)
+    db_session.close()
+
+
+def _message_received(client, server, message):
     history = client_id_to_chat_history[client['id']]
     obj = json.loads(message)
     assert isinstance(obj, dict), obj


### PR DESCRIPTION
Prevents errors like these after we open up 15 chat sessions that load history:
```
sqlalchemy.exc.TimeoutError: QueuePool limit of size 5 overflow 10 reached, connection timed out, timeout 30.00 (Background on this error at: https://sqlalche.me/e/14/3o7r)
```