### PR TITLE
requirements: remove gradio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 langchain==0.0.93
-gradio==3.16.2
 openai==0.26.1
 faiss-cpu==1.7.3
 websocket-server==0.6.4


### PR DESCRIPTION
Does not seem used, causes some dep conflict on websocket library vs web3.