### PR TITLE
tools: add error retries to weaviate lookups

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-langchain==0.0.93
+langchain==0.0.103
 openai==0.26.1
 faiss-cpu==1.7.3
 websocket-server==0.6.4
@@ -11,3 +11,4 @@ psycopg2-binary==2.9.5
 qcore==1.8.0
 PyYAML==6.0
 web3==5.31.3
+gpt_index==0.4.23


### PR DESCRIPTION
Occasionally, weaviate might time out and return an error like the following:
```
  File "/Users/kahkeng/projects/yield/backend/tools/index_lookup.py", line 54, in _run
    docs = self._index.similarity_search(query, k=self._top_k)
  File "/Users/kahkeng/projects/yield/venv/lib/python3.10/site-packages/langchain/vectorstores/weaviate.py", line 87, in similarity_search
    for res in result["data"]["Get"][self._index_name]:
TypeError: 'NoneType' object is not iterable
```

Proper error handling probably needs to be done inside langchain by inspecting the result dictionary for the error message, but since this causes our app to break right now, we add some quick fix bandaid to retry these exceptions.

For now, I'm using a util function that I wrote that got contributed to gpt_index, but we can inline it here too if that's preferred. langchain had to be upgraded as well to stay compatible with gpt_index version.
