### PR TITLE
chat: be more crisp about handling whitespace prefixes

### DIFF
--- a/chat/basic_agent.py
+++ b/chat/basic_agent.py
@@ -63,7 +63,7 @@ class BasicAgentChat(BaseChat):
         def system_flush(response):
             nonlocal system_chat_message_id
             send(Response(
-                response=response,
+                response=response.strip(),
                 still_thinking=True,
                 actor='system',
                 operation='replace',
@@ -72,7 +72,7 @@ class BasicAgentChat(BaseChat):
         def bot_flush(response):
             nonlocal bot_chat_message_id
             send(Response(
-                response=response,
+                response=response.strip(),
                 still_thinking=False,
                 actor='bot',
                 operation='replace',
@@ -104,6 +104,9 @@ class BasicAgentChat(BaseChat):
                 system_response = ''
 
             bot_response += token
+            if not bot_response.strip():
+                # don't start returning something until we have the first non-whitespace char
+                return
             bot_chat_message_id = send(Response(
                 response=token,
                 still_thinking=False,


### PR DESCRIPTION
If we start returning the first character and it is a whitespace, it removes the thinking indicator but might stay blank for a while, whilst the backend widget fetches are ongoing. This fixes that.