### PR TITLE
chat: update history to store individual messages instead of paired interactions

### DIFF
--- a/chat/basic_agent.py
+++ b/chat/basic_agent.py
@@ -49,10 +49,9 @@ class BasicAgentChat(BaseChat):
 
     def receive_input(self, history: ChatHistory, userinput: str, send: Callable) -> None:
         userinput = userinput.strip()
-        history_string = ""
-        for interaction in history:
-            history_string += ("User: " + interaction.input + "\n")
-            history_string += ("Assistant: " + interaction.response + "\n")
+        history_string = history.to_string()
+
+        history.add_user_message(userinput)
         start = time.time()
 
         system_chat_message_id = None
@@ -77,7 +76,7 @@ class BasicAgentChat(BaseChat):
                 actor='bot',
                 operation='replace',
             ), last_chat_message_id=bot_chat_message_id)
-            history.add_interaction(userinput, response)
+            history.add_bot_message(response)
 
         def system_new_token_handler(token):
             nonlocal system_chat_message_id, system_response, bot_chat_message_id, bot_response

--- a/chat/rephrase.py
+++ b/chat/rephrase.py
@@ -93,10 +93,7 @@ class RephraseChat(BaseChat):
         userinput = userinput.strip()
         if history:
             # First rephrase the question
-            history_string = ""
-            for interaction in history:
-                history_string += ("User: " + interaction.input + "\n")
-                history_string += ("Assistant: " + interaction.response + "\n")
+            history_string = history.to_string()
             question = self.rephrase_chain.run({
                 "history": history_string.strip(),
                 "question": userinput,

--- a/chat/rephrase_cited.py
+++ b/chat/rephrase_cited.py
@@ -97,10 +97,7 @@ class RephraseCitedChat(BaseChat):
         userinput = userinput.strip()
         if history:
             # First rephrase the question
-            history_string = ""
-            for interaction in history:
-                history_string += ("User: " + interaction.input + "\n")
-                history_string += ("Assistant: " + interaction.response + "\n")
+            history_string = history.to_string()
             question = self.rephrase_chain.run({
                 "history": history_string.strip(),
                 "question": userinput,

--- a/chat/simple.py
+++ b/chat/simple.py
@@ -41,10 +41,7 @@ class SimpleChat(BaseChat):
     def receive_input(self, history: ChatHistory, userinput: str, send: Callable) -> None:
         docs = self.doc_index.similarity_search(userinput, k=self.top_k)
         task_info = ''.join([doc.page_content for doc in docs])
-        history_string = ""
-        for interaction in history:
-            history_string += ("User: " + interaction.input + "\n")
-            history_string += ("Assistant: " + interaction.response + "\n")
+        history_string = history.to_string()
         history_string += ("User: " + userinput )
         result = self.chain.run({
             "task_info": task_info,

--- a/chat/widget_search.py
+++ b/chat/widget_search.py
@@ -109,10 +109,7 @@ class WidgetSearchChat(BaseChat):
     def receive_input(self, history: ChatHistory, userinput: str, send: Callable) -> None:
         userinput = userinput.strip()
         # First identify the question
-        history_string = ""
-        for interaction in history:
-            history_string += ("User: " + interaction.input + "\n")
-            history_string += ("Assistant: " + interaction.response + "\n")
+        history_string = history.to_string()
         start = time.time()
         example = {
             "history": history_string.strip(),

--- a/server.py
+++ b/server.py
@@ -107,27 +107,15 @@ def _load_existing_history_and_messages(session_id):
     history = chat.ChatHistory.new(session_id)
     messages = []
 
-    last_user_message = None
-    last_bot_message = None
     for message in ChatMessage.query.filter(ChatMessage.chat_session_id == session_id).order_by(ChatMessage.created).all():
         messages.append(message)
 
-        # register user <-> bot interactions
+        # register user/bot messages to history
         if message.type == 'text':
             if message.actor == 'user':
-                # for now, only restore the last bot message as interaction
-                if last_bot_message is not None:
-                    assert last_user_message is not None
-                    history.add_interaction(last_user_message, last_bot_message)
-                    last_bot_message = None
-                last_user_message = message.payload
-
+                history.add_user_message(message.payload)
             elif message.actor == 'bot':
-                last_bot_message = message.payload
-
-    if last_bot_message is not None:
-        assert last_user_message is not None
-        history.add_interaction(last_user_message, last_bot_message)
+                history.add_bot_message(message.payload)
 
     return history, messages
 


### PR DESCRIPTION
This addresses a defect where we don't store intermediate bot responses into history when reloading an old conversation, and duplicate user input to make pairs for a live conversation.

This would also set us up better for ChatGPT / ChatML message struct integration in future.