### PR TITLE
backend: set same_site to none for dev/prod

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ app.add_middleware(
     SessionMiddleware,
     secret_key=env.env_config['server']['secret_key'],
     max_age=None,
-    same_site='lax',
+    same_site='lax' if env.is_local() else 'none',
     https_only=not env.is_local(),
 )
 


### PR DESCRIPTION
With 'lax' or 'strict', cross-origin requests won't have the right cookies. We can set it to 'none' to disable this and let cookies through, but we must have secure set (https_only=True) for this to be allowed.

https://stackoverflow.com/questions/59990864/what-is-the-difference-between-samesite-lax-and-samesite-strict

We'll double-check dev tools to see if it is indeed secure.