### PR TITLE
env: make local example point to dev chatdb by default

### DIFF
--- a/env/local.example.yaml
+++ b/env/local.example.yaml
@@ -1,8 +1,8 @@
 # Local environment
 
 chatdb:
-  host: 127.0.0.1
-  port: 5433
+  host: 34.139.225.26
+  port: 5432
   user: chatdb
   password: lVIu2U0lBctiYBScboAJ
 


### PR DESCRIPTION
Users can override with local postgres as needed, but most of the time, people can just use the dev db.