### PR TITLE
tools: move two index-lookup based tools into widgets

### DIFF
--- a/chat/fine_tuned.py
+++ b/chat/fine_tuned.py
@@ -119,13 +119,21 @@ class FineTunedChat(BaseChat):
                 if '|>' in response_buffer:
                     # parse fetch command
                     response_buffer = iterative_evaluate(response_buffer)
-                    if isinstance(response_buffer, Generator):  # handle stream of widgets
+                    if isinstance(response_buffer, Callable):  # handle delegated streaming
+                        def handler(token):
+                            nonlocal new_token_handler
+                            timing.log('first_visible_widget_response_token')
+                            return new_token_handler(token)
+                        response_buffer(handler)
+                        response_buffer = ""
+                        return
+                    elif isinstance(response_buffer, Generator):  # handle stream of widgets
                         for item in response_buffer:
                             timing.log('first_visible_widget_response_token')
                             new_token_handler(str(item) + "\n")
                         response_buffer = ""
                         return
-                    if len(response_buffer.split('<|')) == len(response_buffer.split('|>')):
+                    elif len(response_buffer.split('<|')) == len(response_buffer.split('|>')):
                         # matching pairs of open/close, just flush
                         # NB: for better frontend parsing of nested widgets, we need an invariant that
                         # there are no two independent widgets on the same line, otherwise we can't

--- a/chat/rephrase_widget_search.py
+++ b/chat/rephrase_widget_search.py
@@ -170,13 +170,21 @@ class RephraseWidgetSearchChat(BaseChat):
                     if '|>' in response_buffer:
                         # parse fetch command
                         response_buffer = iterative_evaluate(response_buffer)
-                        if isinstance(response_buffer, Generator):  # handle stream of widgets
+                        if isinstance(response_buffer, Callable):  # handle delegated streaming
+                            def handler(token):
+                                nonlocal new_token_handler
+                                timing.log('first_visible_widget_response_token')
+                                return new_token_handler(token)
+                            response_buffer(handler)
+                            response_buffer = ""
+                            return
+                        elif isinstance(response_buffer, Generator):  # handle stream of widgets
                             for item in response_buffer:
                                 timing.log('first_visible_widget_response_token')
                                 new_token_handler(str(item) + "\n")
                             response_buffer = ""
                             return
-                        if len(response_buffer.split('<|')) == len(response_buffer.split('|>')):
+                        elif len(response_buffer.split('<|')) == len(response_buffer.split('|>')):
                             # matching pairs of open/close, just flush
                             # NB: for better frontend parsing of nested widgets, we need an invariant that
                             # there are no two independent widgets on the same line, otherwise we can't

--- a/config.py
+++ b/config.py
@@ -3,7 +3,7 @@ import registry
 
 widget_index = dict(
     type="index.weaviate.WeaviateIndex",
-    index_name="WidgetV10",
+    index_name="WidgetV11",
     text_key="content",
 )
 app_info_index = dict(
@@ -39,36 +39,11 @@ default_config = dict(
         type="chat.basic_agent.BasicAgentChat",
         tools=[
             dict(
-                type="tools.index_answer.IndexAnswerTool",
-                _streaming=True,  # if specified, this is lazily constructed in chat to support streaming
-                name="ScrapedSitesIndexAnswer",
-                content_description="general content scraped from web3 sites. It does not know about this app or about widget magic commands for invoking transactions or fetching data about specific things like NFTs or balances.",
-                index=scraped_sites_index,
-                top_k=3,
-                source_key="url",
-            ),
-            dict(
                 type="tools.index_widget.IndexWidgetTool",
                 _streaming=True,  # if specified, this is lazily constructed in chat to support streaming
                 name="WidgetIndexAnswer",
                 index=widget_index,
                 top_k=10,
-            ),
-            dict(
-                type="tools.index_app_info.IndexAppInfoTool",
-                _streaming=True,  # if specified, this is lazily constructed in chat to support streaming
-                name="AppInfoIndexAnswer",
-                index=app_info_index,
-                top_k=3,
-            ),
-            dict(
-                type="tools.index_api_tool.IndexAPITool",
-                _streaming=True,
-                name="IndexAPITool",
-                index=api_docs_index,
-                crypto_tokens_index=crypto_tokens_index,
-                top_k=1,
-                return_direct=True,
             ),
         ],
     )

--- a/index/widgets.py
+++ b/index/widgets.py
@@ -6,7 +6,7 @@ from langchain.docstore.document import Document
 from .weaviate import get_client
 
 
-INDEX_NAME = 'WidgetV10'
+INDEX_NAME = 'WidgetV11'
 INDEX_DESCRIPTION = "Index of widgets"
 TEXT_KEY = 'content'
 

--- a/knowledge_base/widgets.txt
+++ b/knowledge_base/widgets.txt
@@ -181,7 +181,7 @@ Required Parameters:
 -{value}: value of the text record
 ---
 Widget magic command: <|set-ens-primary-name({domain})|>
-Description of widget: This widget is used when the user wants to set a primary ENS name for their connected wallet account 
+Description of widget: This widget is used when the user wants to set a primary ENS name for their connected wallet account
 Required Parameters:
 -{domain}: domain name to use as primary ENS name
 ---
@@ -223,3 +223,17 @@ Required Parameters:
 -{network}: network or blockchain of the project. Default to Ethereum if not specified
 -{token}: token to deposit in the project
 -{amount}: amount of token to deposit in the project
+---
+Widget magic command: <|fetch-app-info({query})|>
+Description of widget: This widget is used when we need to handle common questions and answers about the chat assistant app, what it can do, how to interact with it, at a high-level. Only useful for questions about the chat app experience. It does not know specific information about the web3 ecosystem, of tokens or NFTs or contracts, or access to live data and APIs.
+Required parameters:
+-{query}: a standalone query with all relevant contextual details pertaining to the chat web application
+Return value description:
+-an answer to the question, with suggested follow-up questions if available
+---
+Widget magic command: <|fetch-scraped-sites({query})|>
+Description of widget: This widget is used when we need to answer questions using general content scraped from web3 sites. It does not know about this app or about widget magic commands for invoking transactions or fetching data about specific things like NFTs or balances.
+Required parameters:
+-{query}: a standalone question representing information to be retrieved from the index
+Return value description:
+-a summarized answer with source citations


### PR DESCRIPTION
Also drop IndexAPITool from BasicAgent config.

I need these as widgets as well for the fine-tuned chat version. Getting successful retrieval for these is not as critical given we can generate data for fine-tuning without needing retrieval.

I was able to test it on Basic Agent and see the response stream back to client despite it being a widget that returns token stream instead of container stream.
<img width="815" alt="image" src="https://github.com/yieldprotocol/chatweb3-backend/assets/141746/349e714b-4899-4a5b-9426-ea4fceb79dc4">
