### PR TITLE
chat: fix issue where short responses don't get returned

### DIFF
--- a/chat/chatgpt_function_call.py
+++ b/chat/chatgpt_function_call.py
@@ -132,8 +132,8 @@ class ChatGPTFunctionCallChat(BaseChat):
                 else:
                     # keep waiting
                     return
-            if len(response_buffer) < len(WIDGET_START):
-                # keep waiting
+            if 0 < len(response_buffer) < len(WIDGET_START) and WIDGET_START.startswith(response_buffer):
+                # keep waiting if we could potentially be receiving WIDGET_START
                 return
             token = response_buffer
             response_buffer = ""

--- a/chat/fine_tuned.py
+++ b/chat/fine_tuned.py
@@ -154,8 +154,8 @@ class FineTunedChat(BaseChat):
             elif response_buffer.startswith(NO_WIDGET_TOKEN):
                 # don't emit this in the stream, we will handle the final response below
                 return
-            elif len(response_buffer) < len(WIDGET_START):
-                # keep waiting
+            elif 0 < len(response_buffer) < len(WIDGET_START) and WIDGET_START.startswith(response_buffer):
+                # keep waiting if we could potentially be receiving WIDGET_START
                 return
             token = response_buffer
             response_buffer = ""

--- a/chat/rephrase_widget_search.py
+++ b/chat/rephrase_widget_search.py
@@ -197,8 +197,8 @@ class RephraseWidgetSearchChat(BaseChat):
                     else:
                         # keep waiting
                         return
-                if len(response_buffer) < len(WIDGET_START):
-                    # keep waiting
+                if 0 < len(response_buffer) < len(WIDGET_START) and WIDGET_START.startswith(response_buffer):
+                    # keep waiting if we could potentially be receiving WIDGET_START
                     return
                 token = response_buffer
                 response_buffer = ""

--- a/chat/rephrase_widget_search2.py
+++ b/chat/rephrase_widget_search2.py
@@ -167,8 +167,8 @@ class RephraseWidgetSearchChat(BaseChat):
                     else:
                         # keep waiting
                         return
-                if len(response_buffer) < len(WIDGET_START):
-                    # keep waiting
+                if 0 < len(response_buffer) < len(WIDGET_START) and WIDGET_START.startswith(response_buffer):
+                    # keep waiting if we could potentially be receiving WIDGET_START
                     return
                 token = response_buffer
                 response_buffer = ""

--- a/tools/index_widget.py
+++ b/tools/index_widget.py
@@ -126,8 +126,8 @@ class IndexWidgetTool(IndexLookupTool):
                         # keep waiting
                         return
 
-                if len(response_buffer) < len(WIDGET_START):
-                    # keep waiting
+                if 0 < len(response_buffer) < len(WIDGET_START) and WIDGET_START.startswith(response_buffer):
+                    # keep waiting if we could potentially be receiving WIDGET_START
                     return
                 token = response_buffer
                 response_buffer = ""


### PR DESCRIPTION
If <|fetch-my-balance(ETH)|> returned 0 for example, this would fall into the waiting step and not get returned. Only wait to return if it could still end up returning WIDGET_START. In practice, this only means the '<' character will get dropped if that was all that was getting returned.