### PR TITLE
config: make basic agent the default again

### DIFF
--- a/config.py
+++ b/config.py
@@ -37,10 +37,16 @@ crypto_tokens_index = dict(
 default_config = dict(
     type="system.System",
     chat=dict(
-        type="chat.chatgpt_function_call.ChatGPTFunctionCallChat",
-        model_name='gpt-4-0613',
-        widget_index=widget_index,
-        top_k=32,
+        type="chat.basic_agent.BasicAgentChat",
+        tools=[
+            dict(
+                type="tools.index_widget.IndexWidgetTool",
+                _streaming=True,  # if specified, this is lazily constructed in chat to support streaming
+                name="WidgetIndexAnswer",
+                index=widget_index,
+                top_k=10,
+            ),
+        ],
     )
 )
 


### PR DESCRIPTION
Until functions.json and widgets.txt is unified.

Basic Agent looks at widgets.txt but ChatGPT Functions looks at functions.json.

