### PR TITLE
chat: update system prompt to confirm less

### DIFF
--- a/chat/chatgpt_function_call.py
+++ b/chat/chatgpt_function_call.py
@@ -31,7 +31,7 @@ from ui_workflows.multistep_handler import register_ens_domain, exec_aave_operat
 from tools.index_widget import *
 
 SYSTEM_MESSAGE_FOR_EVAL = "You are an agent that is trained to execute functions based on a user request. Use an empty string if the input parameter value is unknown."
-SYSTEM_MESSAGE_DEFAULT = "You are an agent that is trained to execute functions based on a user request. Ask the user if any of the input parameter value is unknown."
+SYSTEM_MESSAGE_DEFAULT = "You are an agent that is trained to execute functions based on a user request. If you found a suitable function but not all the input parameters are known, ask for them."
 
 @registry.register_class
 class ChatGPTFunctionCallChat(BaseChat):


### PR DESCRIPTION
A question like "What is my balance of DAI" might sometimes ask for the token, but now should just issue the query directly.

Same for clicking the swap example query from the homepage, we now get the swap widget immediately, instead of "To execute the function, I need to confirm the following parameters: - Token to sell: ETH - Token to buy: DAI - Transaction keyword: SELLAMOUNT - Amount to sell: 0.1 Is this correct?"
