### PR TITLE
server: fix session clearing unexpectedly

### DIFF
--- a/server.py
+++ b/server.py
@@ -212,15 +212,19 @@ def message_received(client_state, send_response, message):
         resume_from_message_id = payload.get('resumeFromMessageId')
         before_message_id = payload.get('insertBeforeMessageId')
 
-        # send a message to clear frontend message list
-        msg = json.dumps({
-            'messageId': '',
-            'actor': 'system',
-            'type': 'clear',
-            'payload': '',
-            'feedback': 'n/a',
-        })
-        send_response(msg)
+        # send a message to clear frontend message list, if we expect a fresh session.
+        # this is sometimes needed if we switch sessions quickly on frontend before an
+        # earlier session has fully loaded, and we end up with messages from a different
+        # session still loading in.
+        if resume_from_message_id is None:
+            msg = json.dumps({
+                'messageId': '',
+                'actor': 'system',
+                'type': 'clear',
+                'payload': '',
+                'feedback': 'n/a',
+            })
+            send_response(msg)
 
         if not _ensure_can_view_chat_session(session_id, client_state, send_response):
             return


### PR DESCRIPTION
When the websocket connection closes (there's some connection time limit in the deployed environments), the frontend re-initializes but we should only clear out messages if we are not resuming/re-initializing.

Should fix #182.