### PR TITLE
cloudbuild: increase concurrency limits

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -24,8 +24,8 @@ steps:
    - '--cpu=2'
    - '--memory=1Gi'
    - '--min-instances=1'
-   - '--max-instances=3'
-   - '--concurrency=5'
+   - '--max-instances=30'
+   - '--concurrency=50'
    - '--set-secrets=OPENSEA_API_KEY=OPENSEA_API_KEY:latest,CENTER_API_KEY=CENTER_API_KEY:latest'
 
 # _SERVICE_NAME and _ENV_TAG are custom substitutions defined within


### PR DESCRIPTION
We might need to split traffic by type to different services. E.g. login/logout should have highest priority, and not be sharing instances with chat websockets or GET requests. GETs could probably have higher concurrency, websockets maybe not if they are long running or might trigger heavyweight Playwright processes.