### PR TITLE
start: update alembic warning remediation steps

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -4,7 +4,7 @@
 if [[ -z "${SKIP_DB_CHECK}" ]]
 then
     echo "Checking current database revision..."
-    alembic check || { echo "WARNING: Database schema not in sync. Run \"ENV_TAG=$ENV_TAG ./db_schema_sync.sh\" to update the $ENV_TAG database, or prepend SKIP_DB_CHECK=1 to your command to ignore this warning."; exit 1; }
+    alembic check || { echo "WARNING: Database schema not in sync. Run \"git pull\" to pick up any migrations that got deployed, or run \"ENV_TAG=local ./db_schema_sync.sh\" to update your local database of pending mgirations, or prepend SKIP_DB_CHECK=1 to your command to ignore this warning."; exit 1; }
 fi
 
 xvfb_cmd=xvfb-run


### PR DESCRIPTION
Now that schema sync is done upon deploy automatically, the solution if someone updates this is to do a git pull. Don't ask people to run the migration manually unless it is for local.