### PR TITLE
alembic: move local db check to db sync script

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -7,7 +7,6 @@ import sqlalchemy_utils
 
 from alembic import context
 
-import env
 import utils.storage
 
 # this is the Alembic Config object, which provides
@@ -34,9 +33,6 @@ target_metadata = database.models.Base.metadata
 # set database based on environment
 def _set_db_url():
     db_url = utils.storage.CHATDB_URL
-    if env.is_local():
-        # this is to avoid accidentally updating dev when the local config uses the dev db
-        assert 'localhost' in db_url or '127.0.0.1' in db_url, f'expecting localhost in db_url when using ENV_TAG=local with alembic, check env/local.yaml'
     config.set_main_option('sqlalchemy.url', db_url)
 
 _set_db_url()

--- a/db_schema_sync.sh
+++ b/db_schema_sync.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+set -euxf -o pipefail
+
+# This will assert if we run this on local but are pointed to dev db
+python3 -m scripts.verify_local_db
+
 # This will ensure database schema is upgraded to the head revision
 # for the specified ENV_TAG database
 alembic upgrade head

--- a/scripts/verify_local_db.py
+++ b/scripts/verify_local_db.py
@@ -1,0 +1,13 @@
+import env
+import utils.storage
+
+
+def verify_local_db():
+    # this is to avoid accidentally updating dev when the local config uses the dev db
+    db_url = utils.storage.CHATDB_URL
+    assert 'localhost' in db_url or '127.0.0.1' in db_url, f'expecting localhost in db_url when using ENV_TAG=local with alembic, check env/local.yaml'
+
+
+if __name__ == "__main__":
+    if env.is_local():
+        verify_local_db()


### PR DESCRIPTION
Previously this was firing on start.sh which isn't what we want.