### PR TITLE
task: change GH workflow trigger for widget index

### DIFF
--- a/.github/workflows/check-update-widget-index.yaml
+++ b/.github/workflows/check-update-widget-index.yaml
@@ -1,9 +1,7 @@
 name: Check and update widget index
 
 on:
-  workflow_run:
-    workflows: [Check widget translation]
-    types: [completed]
+  push:
     branches: [master, dev]
 
 jobs:


### PR DESCRIPTION
* Changed GH workflow trigger for widget index to happen on push, instead of workflow run as being able to reliably get the branch name needs to be figured out