### PR TITLE
integration: tx replay

### DIFF
--- a/chat/display_widgets.py
+++ b/chat/display_widgets.py
@@ -171,6 +171,9 @@ def _widgetize_inner(command: str, params: str, depth: int = 0) -> str:
     elif command == 'yield-protocol-borrow-close':
         items = params.split(",")
         lines.append(f"yield protocol borrow close action: {items[0]}") 
+    elif command == 'tx-replay':
+        items = params.split(",")
+        lines.append(f"replay transaction") 
     else:
         # assert 0, f'unrecognized command: {command}({params})'
         lines.append(f"An unrecognized command: {command}({params})")

--- a/chat/display_widgets.py
+++ b/chat/display_widgets.py
@@ -173,7 +173,7 @@ def _widgetize_inner(command: str, params: str, depth: int = 0) -> str:
         lines.append(f"yield protocol borrow close action: {items[0]}") 
     elif command == 'tx-replay':
         items = params.split(",")
-        lines.append(f"replay transaction") 
+        lines.append(f"replay transaction with tx hash: {items[0]}") 
     else:
         # assert 0, f'unrecognized command: {command}({params})'
         lines.append(f"An unrecognized command: {command}({params})")

--- a/knowledge_base/widgets.yaml
+++ b/knowledge_base/widgets.yaml
@@ -702,9 +702,10 @@
   description: replay a transaction with the same parameters
   parameters:
     properties:
-      placeholder:
-        description: just a placeholder
+      user_wallet_address:
+        description: just a placeholder; this is the user's wallet address
         type: string
     required:
+      - user_wallet_address
     type: object
   return_value_description: ""

--- a/knowledge_base/widgets.yaml
+++ b/knowledge_base/widgets.yaml
@@ -702,10 +702,10 @@
   description: replay a transaction with the same parameters
   parameters:
     properties:
-      user_wallet_address:
-        description: just a placeholder; this is the user's wallet address
+      txHash:
+        description: the transaction with tx hash to replay
         type: string
     required:
-      - user_wallet_address
+      - txHash
     type: object
   return_value_description: ""

--- a/knowledge_base/widgets.yaml
+++ b/knowledge_base/widgets.yaml
@@ -698,3 +698,13 @@
       - borrowToken
     type: object
   return_value_description: ""
+- _name_: display_tx_replay
+  description: replay a transaction with the same parameters
+  parameters:
+    properties:
+      placeholder:
+        description: just a placeholder
+        type: string
+    required:
+    type: object
+  return_value_description: ""

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -53,7 +53,7 @@ ALCHEMY_API_KEY =  os.getenv('ALCHEMY_API_KEY', None)
 WIDGET_INFO_TOKEN_LIMIT = 4000
 
 # Widget Index
-WIDGET_INDEX_NAME = "WidgetV21"
+WIDGET_INDEX_NAME = "WidgetV22"
 
 def get_widget_index_name():
     if env.is_local():


### PR DESCRIPTION
## Description

Updates the integration/widget yaml for a new integration: replaying any arbitrary transaction (only mainnet for now) via the TransactionReplay widget on the frontend [here](https://github.com/yieldprotocol/cacti-frontend/pull/439). 

The widget enables users to resubmit a transaction as is, or modify any parameters (via the frontend). More work is needed to handle different types, complex objects as parameters, etc. Also, the frontend abi fetching can probably be moved to the backend.